### PR TITLE
dns_zonenodes: Made prefix configurable

### DIFF
--- a/docs/dns_authoritative.md
+++ b/docs/dns_authoritative.md
@@ -38,7 +38,11 @@ dns_zonenodes can be configured as follows:
     - dns_zonenodes_toplevel: "ffh.zone."
     - dns_zonenodes_nodedomain: "n.ffh.zone"
     - dns_zonenodes_rdnsdomain: "8.0.0.0.e.e.f.f.a.c.d.f.ip6.arpa"
+    - dns_zonenodes_matchIP: "/^fdca/"
     - dns_zonenodes_nodeurl: "http://hannover.freifunk.net:8079/nodes.json"
 ```
 the _toplevel variable sets the domain, which is automatically suffixed to every hostname in the 
 dns_authoritative_zones variable to create a correct PTR/rDNS-record.
+
+_matchIP configures a regex which is used to determine which IPv6-address of these found in the router 
+is used for forward resolution of the nodedomain (in this case n.ffh.zone) address. 

--- a/roles/dns_zonenodes/templates/knoten_compile.pl.j2
+++ b/roles/dns_zonenodes/templates/knoten_compile.pl.j2
@@ -74,7 +74,7 @@ if ($response->is_success) {
         my $ip;
         my $names;
         foreach my $node_ip ( @{ $data->{nodes}->{$node_id}->{nodeinfo}->{network}->{addresses} } ) {
-            next if $node_ip !~ m/^fdca/;
+            next if $node_ip !~ m{{ dns_zonenodes_matchIP }};
             $ip = $node_ip; 
         }
         next unless $ip;


### PR DESCRIPTION
As planned with @lemoer , this parameter was made configurable.

We were also talking about implementing LOC resource records to show the geographical position of a node via https://de.wikipedia.org/wiki/LOC_Resource_Record 

This unfortunatly has 2 major downsides, which caused me to not implement this functionality just yet:
a) LOC RRs need coordinates in the WGS84 format, which is relativly non-standard. 
There is a perl module for converting these (Geo::Coordinates::Converter) but AFAIK no debian package, which would make installation a bit complicated and error-prone. 
b) We are using he.net as secondary DNS servers. Implementing LOC RRs would double our record count in the zone, which would bring us dangerously close to limitations for the maximum RR-count per zone. 

As much as I would like to have this functionality, I'd recommend against doing that at the moment. 

Sidenode: configuration changes for this pull request are in https://github.com/freifunkh/ansible-configs/pull/26 