### PR TITLE
mesh_fastd_remotes_peers_git: track peers' last access time

### DIFF
--- a/roles/ffh.mesh_fastd_remotes_peers_git/tasks/main.yml
+++ b/roles/ffh.mesh_fastd_remotes_peers_git/tasks/main.yml
@@ -6,6 +6,12 @@
     dest: /etc/fastd/peers
     owner: auto
 
+- name: Create the peers' activity directory
+  file:
+    state: directory
+    dest: /var/fastd_peers
+    owner: auto
+
 - name: Clone the peers git
   become: yes
   become_user: auto
@@ -29,6 +35,22 @@
       /etc/fastd/peers
       && (sudo /usr/bin/killall -HUP fastd
       || echo "Reload of mesh_fastd instance failed")
+
+- name: Install crontab for peer activity monitoring
+  cron:
+    name: "saves last access time of a peer"
+    user: auto
+    minute: "23"
+    hour: "*/11"
+    job: |
+      /bin/bash -c ' \
+      for i in $(for j in $(for k in /var/run/*.sock; \
+                                do echo $k; \
+                            done | grep "/var/run/fastd";); \
+                     do nc -U "$j" | jq -r ".peers[] | select(.connection != null) | .name"; \
+                 done;); \
+          do touch "/var/fastd_peers/$i"; \
+      done;'
 
 - name: dom0 peers config
   include_tasks: dom0.yml


### PR DESCRIPTION
To get an idea of which keys are still in use this commit introduces a cronjob which uses the status sockets of the fastd instances to retrieve the currently connected peers and touches (updates the last access time of) the files corresponding to the peers' names in the newly created directory '/var/fastd_peers'.
Due to privacy reasons this cronjob is being executed every 11 hours only.

~This depends on #87.~