### PR TITLE
cli_tools: ensure some locales

### DIFF
--- a/roles/ffh.cli_tools/tasks/main.yml
+++ b/roles/ffh.cli_tools/tasks/main.yml
@@ -56,3 +56,10 @@
   with_fileglob:
     - "files/bin/*"
 
+- name: ensure some basic locales
+  locale_gen:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - de_DE.UTF-8
+    - en_GB.UTF-8


### PR DESCRIPTION
This resolves the `setlocale: LC_ALL: cannot change locale` spam off the strato box.

Apparently Strato has a different locale-set on its images, than what we run usually.
This is fine, as long as one does not open ssh sessions to other systems from it.

We do this on a regualr basis with our fastd key repo.
In that case the line `SendEnv LANG LC_*` results in sn07 sending its  LC-entry containing `en_GB.utf8` to ns1, which does not have that locale installed.

The error was thrown by `git pull --quiet` in `/home/auto/autoupdate.sh`.

This PR installs `en_GB.utf8`, which is setup by strato, as well as `de_DE.UTF-8`, which is used on all other supernodes.

This was tested on sn07 and sn08. But is most important on ns1, where the git repos lie.