### PR TITLE
treewide: correct batman -m parameter

### DIFF
--- a/roles/archive/node_exporter/templates/export_batman.sh
+++ b/roles/archive/node_exporter/templates/export_batman.sh
@@ -12,8 +12,8 @@ for batdev in /sys/class/net/bat*; do
 		}
 	'
 
-	echo "batman_originator_count{batdev=\"${batdev}\",selected=\"false\"}" $($BATCTL -m ${batdev} o | egrep '^   ' | wc -l)
-	echo "batman_originator_count{batdev=\"${batdev}\",selected=\"true\"}" $($BATCTL -m ${batdev} o | egrep '^ \*' | wc -l)
-	echo "batman_tg_count{batdev=\"${batdev}\",type=\"multicast\"}" $(($($BATCTL -m ${batdev} tg -m | wc -l)-2))
-	echo "batman_tg_count{batdev=\"${batdev}\",type=\"unicast\"}" $(($($BATCTL -m ${batdev} tg -u | wc -l)-2))
+	echo "batman_originator_count{batdev=\"${batdev}\",selected=\"false\"}" $($BATCTL meshif ${batdev} o | egrep '^   ' | wc -l)
+	echo "batman_originator_count{batdev=\"${batdev}\",selected=\"true\"}" $($BATCTL meshif ${batdev} o | egrep '^ \*' | wc -l)
+	echo "batman_tg_count{batdev=\"${batdev}\",type=\"multicast\"}" $(($($BATCTL meshif ${batdev} tg -m | wc -l)-2))
+	echo "batman_tg_count{batdev=\"${batdev}\",type=\"unicast\"}" $(($($BATCTL meshif ${batdev} tg -u | wc -l)-2))
 done

--- a/roles/ffh.mesh_fastd/templates/fastd.conf.j2
+++ b/roles/ffh.mesh_fastd/templates/fastd.conf.j2
@@ -31,7 +31,7 @@ status socket "/var/run/fastd.{{ mesh_fastd_iface }}.sock";
 
 on up "
  chmod o+rw /var/run/fastd.{{ mesh_fastd_iface }}.sock
- batctl -m bat{{ mesh_fastd_batdev | default(0) }} if add $INTERFACE
+ batctl meshif bat{{ mesh_fastd_batdev | default(0) }} if add $INTERFACE
 {% if sn is defined %}
  ip link set address 88:e6:40:20:{{ '%x' | format(sn) }}0:{% if domain is defined %}{{ '%02d' % domain.id | int }}{% else %}01{% endif %} dev $INTERFACE
 {% endif %}

--- a/roles/ffh.mesh_fastd/templates/fastd.conf_non_sn.j2
+++ b/roles/ffh.mesh_fastd/templates/fastd.conf_non_sn.j2
@@ -31,7 +31,7 @@ status socket "/var/run/fastd.{{ mesh_fastd_iface }}.sock";
 
 on up "
  chmod o+rw /var/run/fastd.{{ mesh_fastd_iface }}.sock
- batctl -m bat{{ mesh_fastd_batdev | default(0) }} if add $INTERFACE
+ batctl meshif bat{{ mesh_fastd_batdev | default(0) }} if add $INTERFACE
 {% if sn is defined %}
  ip link set address 88:e6:40:20:00:{% if domain is defined %}{{ '%02d' % domain.id | int }}{% else %}01{% endif %} dev $INTERFACE
 {% endif %}

--- a/roles/ffh.supernode/files/wait_for_iface.sh
+++ b/roles/ffh.supernode/files/wait_for_iface.sh
@@ -6,7 +6,7 @@ do
     sleep 1
 done
 
-if [$# -eq 1]
+if [ $# -eq 1 ]
 then
     while ! [ "$(cat /sys/class/net/$1/operstate)" = "up" ]
     do

--- a/roles/ffh.zabbix-agent/files/etc/zabbix/bin/export_batman.sh
+++ b/roles/ffh.zabbix-agent/files/etc/zabbix/bin/export_batman.sh
@@ -12,8 +12,8 @@ for batdev in /sys/class/net/bat*; do
 		}
 	'
 
-	echo "batman_originator_count_non_selected{batdev=\"${batdev}\",selected=\"false\"}" $($BATCTL -m ${batdev} o | egrep '^   ' | wc -l)
-	echo "batman_originator_count_selected{batdev=\"${batdev}\",selected=\"true\"}" $($BATCTL -m ${batdev} o | egrep '^ \*' | wc -l)
-	echo "batman_tg_count_multicast{batdev=\"${batdev}\",type=\"multicast\"}" $(($($BATCTL -m ${batdev} tg -m | wc -l)-2))
-	echo "batman_tg_count_unicast{batdev=\"${batdev}\",type=\"unicast\"}" $(($($BATCTL -m ${batdev} tg -u | wc -l)-2))
+	echo "batman_originator_count_non_selected{batdev=\"${batdev}\",selected=\"false\"}" $($BATCTL meshif ${batdev} o | egrep '^   ' | wc -l)
+	echo "batman_originator_count_selected{batdev=\"${batdev}\",selected=\"true\"}" $($BATCTL meshif ${batdev} o | egrep '^ \*' | wc -l)
+	echo "batman_tg_count_multicast{batdev=\"${batdev}\",type=\"multicast\"}" $(($($BATCTL meshif ${batdev} tg -m | wc -l)-2))
+	echo "batman_tg_count_unicast{batdev=\"${batdev}\",type=\"unicast\"}" $(($($BATCTL meshif ${batdev} tg -u | wc -l)-2))
 done


### PR DESCRIPTION
'batman -m' is deprecated and should be replaced by 'batman meshif'.
@codefetch got rid of his warnings, so I just verified it on my branch and suggest changing it in all roles.

https://lists.open-mesh.org/mailman3/hyperkitty/list/b.a.t.m.a.n@lists.open-mesh.org/thread/AHRNDJTW3HNU5NQ5MVI6WZEZZ32PBHZT/