### PR TITLE
[WIP] ffh.exitnode: add MTU fix for QUIC

### DIFF
--- a/host_vars/leintor.yml
+++ b/host_vars/leintor.yml
@@ -16,6 +16,7 @@ networkd_configures:
   gateway4: 81.3.6.89
   gateway6: fe80::1
   dns_server: [81.3.3.81, 8.8.8.8]
+  static_routes: [{ gw: 81.3.6.89, dest: 0.0.0.0/0, table: 43}]
 - iface: lo
   addresses:
     - 100.100.0.1/32 # anycast for ping tests

--- a/roles/ffh.exitnode/files/mtudummy.netdev
+++ b/roles/ffh.exitnode/files/mtudummy.netdev
@@ -1,0 +1,5 @@
+[NetDev]
+Name=mtudummy
+Kind=dummy
+MTUBytes=1298
+

--- a/roles/ffh.exitnode/files/mtudummy.network
+++ b/roles/ffh.exitnode/files/mtudummy.network
@@ -1,0 +1,15 @@
+[Match]
+Name=mtudummy
+
+[Network]
+Address=192.0.0.2/29
+
+[Route]
+Destination=81.3.6.94/32
+Gateway=192.0.0.1
+Table=43
+
+[Route]
+Destination=10.0.0.0/8
+Gateway=192.0.0.1
+Table=43

--- a/roles/ffh.exitnode/files/rc.local
+++ b/roles/ffh.exitnode/files/rc.local
@@ -14,4 +14,8 @@
 /sbin/ip rule add from all fwmark 0x17 table ffnw priority 242
 # /sbin/ip -6 rule add from all fwmark 0x17 table ffnw priority 242
 
+# Route QUIC UDP packets which would exceed our MTU to the "mtudummy" interface
+# to generate ICMP "too big" messages which trigger PMTU on the other side
+/sbin/ip rule add from all fwmark 0x2b table mtudummyrt priority 243
+
 exit 0

--- a/roles/ffh.exitnode/tasks/main.yml
+++ b/roles/ffh.exitnode/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: MTU workaround
+  include_tasks: mtudummy.yml
+
 - name: GRE stuff
   include_tasks: gre.yml
 

--- a/roles/ffh.exitnode/tasks/mtudummy.yml
+++ b/roles/ffh.exitnode/tasks/mtudummy.yml
@@ -1,0 +1,19 @@
+---
+
+- name: Ensure alternative routing table 43 is existing
+  lineinfile:
+    dest: /etc/iproute2/rt_tables
+    line: "43 mtudummyrt"
+
+- name: Create mtudummy.network
+  notify: Restart networkd
+  copy:
+    src: mtudummy.network
+    dest: /etc/systemd/network/10-mtudummy.network
+
+- name: Create mtudummy.netdev
+  notify: Restart networkd
+  copy:
+    src: mtudummy.netdev
+    dest: /etc/systemd/network/10-mtudummy.netdev
+

--- a/roles/ffh.exitnode/tasks/routing.yml
+++ b/roles/ffh.exitnode/tasks/routing.yml
@@ -5,8 +5,8 @@
 
 - name: Deploy /etc/rc.local
   register: rclocal
-  template:
-    src: rc.local.j2
+  copy:
+    src: rc.local
     dest: /etc/rc.local
     mode: u=rwx,g=rx,o=rx
 

--- a/roles/ffh.exitnode/templates/ferm.conf.j2
+++ b/roles/ffh.exitnode/templates/ferm.conf.j2
@@ -6,13 +6,18 @@
       outerface $DEV_EXIT saddr $net REJECT reject-with icmp-host-unreachable;
 }
 
-
 @def &PRIV_NET_DEST_ONLY($net) = {
       outerface $DEV_EXIT daddr $net REJECT reject-with icmp-host-unreachable;
 }
 
 domain (ip) {
   table nat {
+    #chain PREROUTING {
+      # Route QUIC UDP packets which would exceed our MTU to the "mtudummy" interface
+      # to generate ICMP "too big" messages which trigger PMTU on the other side
+    #  interface eth0 proto udp sport 443 mod length length 1299:1500 DNAT to 192.0.0.1;
+    #}
+
     chain POSTROUTING {
       # Alternativly to MASQUERADE use SNAT to <addr>;
       saddr 10.0.0.0/8 outerface eth0 MASQUERADE;
@@ -86,10 +91,36 @@ domain (ip6) {
 domain (ip ip6) {
   table filter {
     chain FORWARD {
+      interface eth0 outerface mtudummy ACCEPT;
 {% for name,node in supernodes.items() %}
       interface eth0 outerface gre-{{ name }} ACCEPT;
       interface gre-{{ name }} outerface eth0 ACCEPT;
 {% endfor %}
+    }
+  }
+}
+
+#domain (ip ip6) {
+#  table raw {
+#    chain PREROUTING {
+      # Disable tracking for oversized QUIC UDP packets to allow processing
+      # by DNAT even if the connection was initiated using masquerading
+#      interface eth0 proto udp sport 443 mod length length 1299:1500 NOTRACK;
+#    }
+#    chain OUTPUT {
+      # Disable tracking for packets that leave on the dummy interface to
+      # avoid blackholing of traffic that is not oversized
+#      outerface mtudummy NOTRACK;
+#    }
+#  }
+#}
+
+domain (ip ip6) {
+  table mangle {
+    chain PREROUTING {
+      # Add a packet mark to oversized QUIC traffic to let it use routing
+      # table 43 so that it is being routed to the dummy interface
+      interface eth0 proto udp sport 443 mod length length 1299:1500 MARK set-xmark 0x2b/0xffffffff;
     }
   }
 }


### PR DESCRIPTION
This commit creates a dummy interface with the "bottleneck" MTU
among our VPN path (currently batadv - see issue #80).
Furthermore it creates an iptables DNAT rule which changes the
destination IP address of incoming QUIC (UDP 443) packets which
exceed the bottleneck MTU to a special IPv4 continuity address
which is part of the subnet of the dummy interface.
When an oversized QUIC packet arrives, it will thus be routed
to the dummy interface which in turn generates an ICMP destination
unreachable (fragmentation needed) packet as the packet does
not fit the MTU of the dummy interface.
The QUIC servers will react to the ICMP packet by changing the
PMTU of their UDP sockets according to the maximum MTU advertised
in the ICMP message, which is the dummy interface's MTU.

It has been tested on sn10. We now need to test if QUIC still works properly. There seems to be still an issue.