### PR TITLE
group_vars: bump batman version 2021.0

### DIFF
--- a/group_vars/batmannodes.yml
+++ b/group_vars/batmannodes.yml
@@ -1,3 +1,3 @@
 batman_build_from_source: true
-batman_build_version: v2020.4
+batman_build_version: v2021.0
 batman: true


### PR DESCRIPTION
This introduces a feature of batman where it does not crash upon hitting an existing bat device.

This was relevant for the pullrequests #94 and #95.

It will provide the 'correct' solution to resolve #98 and grants a possible answer to #111 which would be "just do it everywhere".

Currently it's blocked by numerous issues, as support for sysfs was dropped in 2021.0:

- [x] #139 ffh.supernode: add warning in wait_for_iface.sh
- [x] ~#124 gateway_announcement.sh~
- [x] ~#129 ffh chosen_gw.sh~
- [x] ~#130 wait_for_iface.sh~
- [x] ~#131 main.yml~
- [x] ~#132 export_batman.sh~