### PR TITLE
ffh.supernode: add warning in wait_for_iface.sh

### DIFF
--- a/roles/ffh.supernode/files/wait_for_iface.sh
+++ b/roles/ffh.supernode/files/wait_for_iface.sh
@@ -10,10 +10,9 @@ if [ $# -eq 1 ]
 then
     # usage of operstate is not supported since batman2021.0 anymore
     # no need to catch this further, since 'we get batman systemd support soon'
-    if [[ $1 = bat* ]];
-    then
+    case $1 in bat*)
         echo "Careful, this is likely not supported anymore."
-    fi
+    esac
     while ! [ "$(cat /sys/class/net/$1/operstate)" = "up" ]
     do
         echo  "waiting for $1 to be up"

--- a/roles/ffh.supernode/files/wait_for_iface.sh
+++ b/roles/ffh.supernode/files/wait_for_iface.sh
@@ -8,6 +8,12 @@ done
 
 if [ $# -eq 1 ]
 then
+    # usage of operstate is not supported since batman2021.0 anymore
+    # no need to catch this further, since 'we get batman systemd support soon'
+    if [[ $1 = bat* ]];
+    then
+        echo "Careful, this is likely not supported anymore."
+    fi
     while ! [ "$(cat /sys/class/net/$1/operstate)" = "up" ]
     do
         echo  "waiting for $1 to be up"


### PR DESCRIPTION
batman 2021.0 wont set operstate anymore this is likely the only necessary pr right now...