### PR TITLE
ffh.supernode: delete old GRE interfaces

### DIFF
--- a/roles/ffh.supernode/tasks/gre.yml
+++ b/roles/ffh.supernode/tasks/gre.yml
@@ -1,11 +1,17 @@
 ---
 
 - name: Create network interface for each gre endpoint
-  notify: Restart networkd
   template:
     src: gre-network.j2
     dest: /etc/systemd/network/10-gre-{{ item.key }}.network
   with_dict: "{{ exitnodes }}"
+  register: greconfig
+
+- name: Delete old gre interfaces
+  when: greconfig.changed
+  with_dict: "{{ exitnodes }}"
+  command: "ip link set down gre-{{ item.key }}; ip link del dev gre-{{ item.key }};"
+  notify: Restart networkd
 
 - name: Create /etc/systemd/network/10-eth0.network.d directory
   notify: Restart networkd

--- a/roles/ffh.supernode/tasks/gre.yml
+++ b/roles/ffh.supernode/tasks/gre.yml
@@ -10,6 +10,7 @@
 - name: Delete old gre interfaces
   when: greconfig.changed
   with_dict: "{{ exitnodes }}"
+  ignore_errors: yes
   shell: "ip link set down gre-{{ item.key }}; ip link del dev gre-{{ item.key }};"
   notify: Restart networkd
 

--- a/roles/ffh.supernode/tasks/gre.yml
+++ b/roles/ffh.supernode/tasks/gre.yml
@@ -10,7 +10,7 @@
 - name: Delete old gre interfaces
   when: greconfig.changed
   with_dict: "{{ exitnodes }}"
-  command: "ip link set down gre-{{ item.key }}; ip link del dev gre-{{ item.key }};"
+  shell: "ip link set down gre-{{ item.key }}; ip link del dev gre-{{ item.key }};"
   notify: Restart networkd
 
 - name: Create /etc/systemd/network/10-eth0.network.d directory


### PR DESCRIPTION
Makes sure the new configuration is applied (closes #76).