### PR TITLE
mesh_wireguard addtobatX: remove batman hotfix

### DIFF
--- a/roles/ffh.mesh_wireguard/templates/addtobatX.j2
+++ b/roles/ffh.mesh_wireguard/templates/addtobatX.j2
@@ -4,8 +4,7 @@ After=sys-subsystem-net-devices-{{ vxlan_iface_prefix }}\x2d%i.device
 [Service]
 Type=oneshot
 ExecStart=/bin/sh /usr/bin/wait_for_iface.sh {{ vxlan_iface_prefix }}-%i unknown_is_fine
-ExecStart=/bin/sh /usr/bin/wait_for_iface.sh bat%I unknownisfine
-ExecStart=/sbin/ip link set dev {{ vxlan_iface_prefix }}-%i master bat%I
+ExecStart=/usr/sbin/batctl meshif bat%I if add {{ vxlan_iface_prefix }}-%i
 
 [Install]
 WantedBy=sys-subsystem-net-devices-{{ vxlan_iface_prefix }}\x2d%i.device


### PR DESCRIPTION
batctl 2021.0 got rid of a racecondition, so we do not need to wait for other roles anymore.

tested on sn07.
@CodeFetch , this is what you likely want in your PR as well.