### PR TITLE
Update mesh announce

### DIFF
--- a/roles/ffh.mesh_announce/defaults/main.yml
+++ b/roles/ffh.mesh_announce/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+mesh_announce_cfg_path: "/etc/mesh-announce"

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -25,11 +25,13 @@
     dest: /opt/mesh-announce
     owner: auto
 
+# repo=https://github.com/ffnord/mesh-announce.git
+# change back when https://github.com/ffnord/mesh-announce/pull/64 got merged
 - name: Clone mesh_announce
   become: yes
   become_user: auto
   git: >
-    repo=https://github.com/ffnord/mesh-announce.git
+    repo=https://github.com/freifunkh/mesh-announce.git
     dest=/opt/mesh-announce
     accept_hostkey=true
   register: code

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -19,7 +19,6 @@
     system: yes
     generate_ssh_key: yes
 
-  become: true
 - name: Create mesh_announce directory
   file:
     state: directory
@@ -36,7 +35,6 @@
   register: code
 
 - name: Copy systemd service
-  become: true
   template:
     src: "respondd.service.j2"
     dest: "/lib/systemd/system/respondd.service"
@@ -59,7 +57,6 @@
 
 - name: Restart respondd if something changed
   when: code.changed
-  become: true
   service:
     name: respondd.service
     state: restarted

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -59,17 +59,22 @@
   notify: reload ferm
 
 - name: Systemd daemon-reload
-  command: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
 
 - name: Enable systemd service
-  command: systemctl enable respondd
+  systemd:
+    name: respondd
+    enabled: yes
 
 - name: Start systemd service
-  command: systemctl start respondd
+  systemd:
+    name: respondd
+    state: started
 
 - name: Restart respondd if something changed
   when: code.changed
-  service:
-    name: respondd.service
+  systemd:
+    name: respondd
     state: restarted
 

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -50,6 +50,7 @@
   template:
     src: "respondd.service.j2"
     dest: "/lib/systemd/system/respondd.service"
+  register: service
 
 - name: Generate firewall config stanza (ferm)
   register: ferm_changed
@@ -59,6 +60,7 @@
   notify: reload ferm
 
 - name: Systemd daemon-reload
+  when: service.changed
   systemd:
     daemon_reload: yes
 
@@ -71,9 +73,10 @@
   systemd:
     name: respondd
     state: started
+  register: just_started
 
 - name: Restart respondd if something changed
-  when: code.changed
+  when: not just_started.changed and (code.changed or service.changed)
   systemd:
     name: respondd
     state: restarted

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -34,6 +34,16 @@
     accept_hostkey=true
   register: code
 
+- name: Create configpath
+  file:
+    path: "{{ mesh_announce_cfg_path }}"
+    state: directory
+
+- name: Copy configuration file
+  template:
+    src: "respondd.conf.j2"
+    dest: "{{ mesh_announce_cfg_path }}/respondd.conf"
+
 - name: Copy systemd service
   template:
     src: "respondd.service.j2"

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -19,14 +19,14 @@
     system: yes
     generate_ssh_key: yes
 
-- name: create mesh_announce directory
   become: true
+- name: Create mesh_announce directory
   file:
     state: directory
     dest: /opt/mesh-announce
     owner: auto
 
-- name: clone mesh_announce
+- name: Clone mesh_announce
   become: yes
   become_user: auto
   git: >
@@ -35,7 +35,7 @@
     accept_hostkey=true
   register: code
 
-- name: copy systemd service
+- name: Copy systemd service
   become: true
   template:
     src: "respondd.service.j2"
@@ -57,7 +57,7 @@
 - name: Start systemd service
   command: systemctl start respondd
 
-- name: restart respondd if something changed
+- name: Restart respondd if something changed
   when: code.changed
   become: true
   service:

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -1,0 +1,29 @@
+# Default settings
+[Defaults]
+# Listen port
+# optional, default: 1001
+Port: 1001
+# Default link local listen addresses
+# optional, default: ff02::2:1001
+MulticastLinkAddress: ff02::2:1001
+# Default site local listen addresses
+# optional, default: ff05::2:1001
+MulticastSiteAddress: ff05::2:1001
+# Default domain to use
+# optional, if specified incoming requests that can not be mapped to a domain
+# are mapped to this domain
+DefaultDomain: ffh
+# Default domain type
+# optional, default: simple
+# supported domain types are: simple, batadv
+DomainType: batadv
+# Default ddhcpd IPv4 gateway address
+# optional
+# IPv4Gateway: 10.116.128.8
+
+{% for domain in domains_with_dom0 | default( [] ) %}
+[dom{{ domain.id }}]
+BatmanInterface: bat{{ domain.id }}
+Interfaces: mesh_fastd_{{ domain.id }}
+
+{% endfor %}

--- a/roles/ffh.mesh_announce/templates/respondd.service.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.service.j2
@@ -3,7 +3,7 @@ Description=Respondd
 After=network.target
 
 [Service]
-ExecStart=/opt/mesh-announce/respondd.py -d /opt/mesh-announce/providers {% for domain in domains | default( [] ) %} -i bat{{ domain.id }} -b bat{{ domain.id }}  -i mesh_fastd_{{ domain.id }} {% endfor %} -i bat0 -b bat0 -i mesh_fastd 
+ExecStart=/opt/mesh-announce/respondd.py -d /opt/mesh-announce/providers -f /etc/mesh-announce/respondd.conf
 Restart=always
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 


### PR DESCRIPTION
This closes #146 

More details in commit messages of PR-commits;

Basically upstream implemented https://github.com/ffnord/mesh-announce/pull/60 .
We pulled from their master and broke our config.
This does not happen often; I'd vote for not changing the repos upstream because of this.