### PR TITLE
Enhancement mesh announce

### DIFF
--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Install python3, lsb-release, ethtool, git
+- name: Install python3, python3-psutil, lsb-release, ethtool, git
   apt:
     update_cache: yes
     cache_valid_time: 3600
@@ -8,6 +8,7 @@
   vars:
     packages:
     - python3
+    - python3-psutil
     - lsb-release
     - ethtool
     - git

--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -45,6 +45,7 @@
   template:
     src: "respondd.conf.j2"
     dest: "{{ mesh_announce_cfg_path }}/respondd.conf"
+  register: config
 
 - name: Copy systemd service
   template:
@@ -76,7 +77,7 @@
   register: just_started
 
 - name: Restart respondd if something changed
-  when: not just_started.changed and (code.changed or service.changed)
+  when: not just_started.changed and (code.changed or config.changed or service.changed)
   systemd:
     name: respondd
     state: restarted

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -1,5 +1,8 @@
 # Default settings
 [Defaults]
+# Contact information of Owner
+# optional, default is None
+Contact: fnorden.net
 # Listen port
 # optional, default: 1001
 Port: 1001

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -29,6 +29,14 @@ Hostname: {{ servername }}
 # Is the System considered an Gateway
 # optional, default is True
 VPN: {{ is_supernode or is_superexitnode }}
+# Default vpn protocols to use
+# may contain csv if more than one protocol is used
+# optional, default is fastd
+# supported protocols are: fastd, None
+VPNProtocols: fastd
+# Default fastd-public-key to use
+# optional, default is None
+VPNPublicKey: {{ fastd_keys[servername].public }}
 
 {% for domain in domains_with_dom0 | default( [] ) %}
 [dom{{ domain.id }}]

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -26,6 +26,9 @@ Hostname: {{ servername }}
 # Default ddhcpd IPv4 gateway address
 # optional
 # IPv4Gateway: 10.116.128.8
+# Is the System considered an Gateway
+# optional, default is True
+VPN: {{ is_supernode or is_superexitnode }}
 
 {% for domain in domains_with_dom0 | default( [] ) %}
 [dom{{ domain.id }}]

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -20,6 +20,9 @@ DefaultDomain: ffh
 # optional, default: simple
 # supported domain types are: simple, batadv
 DomainType: batadv
+# Hostname to advertise
+# optional, default is the System Hostname
+Hostname: {{ servername }}
 # Default ddhcpd IPv4 gateway address
 # optional
 # IPv4Gateway: 10.116.128.8


### PR DESCRIPTION
This brings various changes to our mesh_announce instance, that I tested, which are not yet part of mesh_announce upstream.

Tested on sn01 and sn07.

One is the announcement of the fastd publickey, that we already publish as part of our site/domain.conf publicly.