### PR TITLE
Feature wireguard in yanic

### DIFF
--- a/roles/ffh.yanic/files/patches/0002-data-add-WireGuard-struct.patch
+++ b/roles/ffh.yanic/files/patches/0002-data-add-WireGuard-struct.patch
@@ -1,0 +1,46 @@
+From f2230a64487c2ce36d728081bbfdf5398fe593f0 Mon Sep 17 00:00:00 2001
+From: "aiyion.prime" <git@aiyionpri.me>
+Date: Mon, 15 Feb 2021 15:04:11 +0100
+Subject: [PATCH] data: add WireGuard struct
+
+resolves #183
+---
+ data/nodeinfo.go            | 5 +++++
+ data/testdata/nodeinfo.json | 5 +++++
+ 2 files changed, 10 insertions(+)
+
+diff --git a/data/nodeinfo.go b/data/nodeinfo.go
+index 86cff15..d81ce2c 100644
+--- a/data/nodeinfo.go
++++ b/data/nodeinfo.go
+@@ -80,6 +80,11 @@ type Software struct {
+ 	StatusPage struct {
+ 		API int `json:"api"`
+ 	} `json:"status-page,omitempty"`
++	WireGuard struct {
++		Enabled   bool   `json:"enabled,omitempty"`
++		PublicKey string `json:"public_key,omitempty"`
++		Version   string `json:"version,omitempty"`
++	} `json:"wireguard,omitempty"`
+ }
+ 
+ // Hardware struct
+diff --git a/data/testdata/nodeinfo.json b/data/testdata/nodeinfo.json
+index bdd1e11..ef39de9 100644
+--- a/data/testdata/nodeinfo.json
++++ b/data/testdata/nodeinfo.json
+@@ -18,6 +18,11 @@
+     },
+     "status-page": {
+       "api": 1
++    },
++    "wireguard": {
++      "enabled": true,
++      "public_key": "0000000000000000000000000000000000000000000=",
++      "version": "1.0.20210124"
+     }
+   },
+   "network": {
+-- 
+2.30.1
+


### PR DESCRIPTION
This includes a patch which allows wireguard entries in respondd/software.

We'll want this for our wireguard nodes.