### PR TITLE
Implement experimental_supernodes variable

### DIFF
--- a/inventory
+++ b/inventory
@@ -5,6 +5,10 @@ all:
       ansible_host: sn01.s.ffh.zone
     sn05:
       ansible_host: sn05.s.ffh.zone
+    sn06:
+      ansible_host: sn06.s.ffh.zone
+    sn07:
+      ansible_host: sn07.s.ffh.zone
     sn09:
       ansible_host: sn09.s.ffh.zone
     sn10:
@@ -33,7 +37,7 @@ supernodes:
     sn05:
     sn09:
     sn10:
- 
+
 superexitnodes:
   hosts:
     sn01:

--- a/playbooks/supernodes.yml
+++ b/playbooks/supernodes.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: supernodes
+- hosts: "supernodes:{{ experimental_supernodes | default('') }}"
   pre_tasks:
     - name: install etckeeper
       package:
@@ -14,7 +14,7 @@
       tags: [always]
       check_mode: no
     - name: etckeeper pre-commit
-      shell: 'etckeeper commit "pre-commit changes before Ansible runs ({{local_username.stdout}}, tags: {{ansible_run_tags | join(",")}})" || echo "nothing to commit"'
+      shell: 'etckeeper commit "pre-commit changes before Ansible runs ({{ local_username.stdout }}, tags: {{ ansible_run_tags | join(",") }})" || echo "nothing to commit"'
       register: pre_result
       changed_when: pre_result.stdout.find('nothing to commit') == -1
       tags: [always]
@@ -51,7 +51,7 @@
     - { name: ffh.bpfcount, tags: bpfcount }
   post_tasks:
     - name: etckeeper post-commit
-      shell: 'etckeeper commit "post-commit changes after Ansible run ({{local_username.stdout}}, tags: {{ansible_run_tags | join(",")}})" || echo "nothing to commit"'
+      shell: 'etckeeper commit "post-commit changes after Ansible run ({{ local_username.stdout }}, tags: {{ ansible_run_tags | join(",") }})" || echo "nothing to commit"'
       register: post_result
       changed_when: post_result.stdout.find('nothing to commit') == -1
       tags: [always]
@@ -70,7 +70,7 @@
       tags: [always]
       check_mode: no
     - name: etckeeper pre-commit
-      shell: 'etckeeper commit "pre-commit changes before Ansible runs ({{local_username.stdout}}, tags: {{ansible_run_tags | join(",")}})" || echo "nothing to commit"'
+      shell: 'etckeeper commit "pre-commit changes before Ansible runs ({{ local_username.stdout }}, tags: {{ ansible_run_tags | join(",") }})" || echo "nothing to commit"'
       register: pre_result
       changed_when: pre_result.stdout.find('nothing to commit') == -1
       tags: [always]
@@ -78,7 +78,7 @@
     - { name: ffh.superexitnode, tags: superexitnode }
   post_tasks:
     - name: etckeeper post-commit
-      shell: 'etckeeper commit "post-commit changes after Ansible run ({{local_username.stdout}}, tags: {{ansible_run_tags | join(",")}})" || echo "nothing to commit"'
+      shell: 'etckeeper commit "post-commit changes after Ansible run ({{ local_username.stdout }}, tags: {{ ansible_run_tags | join(",") }})" || echo "nothing to commit"'
       register: post_result
       changed_when: post_result.stdout.find('nothing to commit') == -1
       tags: [always]


### PR DESCRIPTION
By default experimental supernodes are not rolled out. The newly
introcuced variable "experimental_supernodes" can be used to roll them.

The variable can be specified by adding the -e switch to your
ansible-playbook call:

    ansible-playbook -e experimental_supernodes=sn06:sn07 ...

This command will roll the supernodes playbook also on the
experimental supernodes sn06 and sn07. Note that multiple supernodes
are separated by ":".

---

## Nutzungs-Policy (Vorschlag, Revision 2)

Zusätzlich zu der technischen Implementierung brauchen wir noch eine interne Policy, wie wir das Feature nutzen. Da wir in letzter Zeit häufiger gleichzeitig an Features arbeiten und wir uns nicht gegenseitig im Weg stehen wollen, wurden experimentelle Supernodes eingeführt. Diese experimentellen Supernodes gehören im wesentlichen jeweils einer zuständigen Person und diese Person sollte sich darauf verlassen können, dass sie die einzige Person ist, die dort Probleme verursacht. Deshalb sollten andere Personen aus dem Kernteam keine Rollen auf den experimentellen Supernodes ausrollen. Nach expliziter Absprache mit der zuständigen Person können Ausnahmen gemacht werden.

Momentan gibt es folgende Zuständigkeiten:
- sn07 - @AiyionPrime 
- sn06 - @CodeFetch 

Bedingungen für die experimentelle Supernodes:
- Es soll sichergestellt werden, dass keine negativen Auswirkungen auf die Ottonormalnutzer von Freifunk entstehen. Dies geschieht, indem die fastd-keys bzw. wireguard-keys der experimentellen Supernodes nicht in offiziell releaste Routerimages eingebacken sein dürfen. Die experimentellen Supernodes müssen temporäre Keys nutzen, die nur in experimentellen Routerimages verfügbar sind.

---
Revisionen:
1. Initialer Wurf.
2. Bedingung mit temporären fastd-/wireguard-keys hinzugefügt.

---

Falls es Diskussionsbedarf zur Policy gibt, würde ich vorschlagen, dass wir das irgendwann im Mumble klären. Falls nicht, könnt ihr hier gern ein ACK geben, um die Policy abzusegnen und kenntlich zu machen, dass ihr sie zur Kenntnis genommen habt.  