### PR TITLE
ffh.yanic: disable checkmode for git-cat-file

### DIFF
--- a/roles/ffh.yanic/tasks/main.yml
+++ b/roles/ffh.yanic/tasks/main.yml
@@ -65,6 +65,7 @@
     cmd: "git cat-file -e {{ yanic_commit }}^{commit}"
   register: commit_search
   changed_when: commit_search.rc!=0
+  check_mode: no
   failed_when: commit_search.rc != 0 and commit_search.rc != 128
 
 - name: Update yanic to "{{ yanic_commit }}"


### PR DESCRIPTION
This is the best I can come up with, without rewriting the git module or creating on for git-cat-file.
It's tested in dry run against harvester.

@1977er If you think this is good enough, feel free to merge.

> this does change things on the system, but not important ones.
> this closes #171