### PR TITLE
Hotfix wrong default routers

### DIFF
--- a/roles/ffh.supernode/templates/gre-network.j2
+++ b/roles/ffh.supernode/templates/gre-network.j2
@@ -3,3 +3,38 @@ Name=gre-{{ item.key }}
 
 [Network]
 Address=100.{{ 100 + exitnodes[item.key].id }}.{{ sn }}.2/24
+
+{% for hostname, exitnode in exitnodes.items() %}
+{% if hostname == item.key %}
+{% for ip_range in exitnode.exit_ip_ranges %}
+{% if ":" in ip_range %}
+# The following lines add source specific routes. These routes are necessary
+# since we announce multiple ipv6 prefixes via radvd into our network. Announcing
+# multiple ipv6 prefixes leads to problems with gluon nodes discussed here:
+# - https://github.com/freifunk-gluon/gluon/issues/2180
+# - https://github.com/freifunkh/ansible/issues/155
+[Route]
+Destination=::/0
+Source={{ ip_range }}
+Table=42
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% for hostname, exitnode in superexitnodes.items() %}
+{% if hostname == item.key %}
+{% for ip_range in exitnode.exit_ip_ranges %}
+{% if ":" in ip_range %}
+# The following lines add source specific routes. These routes are necessary
+# since we announce multiple ipv6 prefixes via radvd into our network. Announcing
+# multiple ipv6 prefixes leads to problems with gluon nodes discussed here:
+# - https://github.com/freifunk-gluon/gluon/issues/2180
+# - https://github.com/freifunkh/ansible/issues/155
+[Route]
+Destination=::/0
+Source={{ ip_range }}
+Table=42
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endfor %}


### PR DESCRIPTION
This is a draft for #155.

Currently it introduces a lookuptable which specifies a defaultrouters LL address in order to route 'its'  traffic to him.

> The same goes for sn01. Sn01 should route packets to leintor, if they are
supposed to be ausgeleitet by leintor (by their source ip).

This has only been roled out to sn01 yet, as it would introduce changes to the other supernodes, that are not useful, yet.

For this to become useful for them as well we need to decide on @lemoer s raised options:

> 2. ... add a route on sn05, sn09 and sn10 towards sn01 (based on source).
>
> Alternatively instead of 2., we could let sn05, sn09 and sn10 let route
packets first to leintor (as they would normally do) and install a source
specific route on leintor then. This would also direct packets to the
correct destination. This one might be easier as gre-tunnels tunnels are
existing and it has to be installed only at one place.

_Originally posted by @lemoer in https://github.com/freifunkh/ansible/issues/155#issuecomment-786523227_

Either way, this currently only changes the supernodes role, not the ones of exitnodes.
