### PR TITLE
mesh_announce: add missing wireguard interfaces

### DIFF
--- a/roles/ffh.ferm/templates/ferm.conf.j2
+++ b/roles/ffh.ferm/templates/ferm.conf.j2
@@ -43,7 +43,9 @@ domain (ip ip6) {
             interface (mesh_fastd) jump MESH_INPUT;
 {% endif %}
 {%if batman is defined and domains is defined %}
-            interface ({% for d in domains %}mesh_fastd_{{d.id}} {% endfor %}) jump MESH_INPUT;
+{% for intf_prefix in ["mesh_fastd_", "vlan-gt-2", "vx-"] %}
+            interface ({% for d in domains %}{{intf_prefix}}{{d.id}} {% endfor %}) jump MESH_INPUT;
+{% endfor %}
 {% endif %}
 
 {%if batman is defined and legacy_dom0 == true %}

--- a/roles/ffh.mesh_announce/templates/ferm.conf.j2
+++ b/roles/ffh.mesh_announce/templates/ferm.conf.j2
@@ -1,7 +1,10 @@
 domain (ip ip6) {
   table filter {
     chain MESH_INPUT {
-      proto udp dport (1001) ACCEPT;
+      proto udp {
+        dport (1001) ACCEPT;
+        saddr fe80::/64 sport 1001 dport 32768:61000 mod comment comment "mesh_respondd_reply" ACCEPT;
+      }
     }
   }
 }

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -41,6 +41,6 @@ VPNPublicKey: {{ fastd_keys[servername].public }}
 {% for domain in domains_with_dom0 | default( [] ) %}
 [dom{{ domain.id }}]
 BatmanInterface: bat{{ domain.id }}
-Interfaces: mesh_fastd_{{ domain.id }}
+Interfaces: mesh_fastd_{{ domain.id }},vlan-gt-2{{ domain.id }},vx-{{ domain.id }}
 
 {% endfor %}


### PR DESCRIPTION
This adds the wireguard-setup related interfaces to mesh-announce.