### PR TITLE
mesh-announce: add locations for supernodes

### DIFF
--- a/host_vars/sn05.yml
+++ b/host_vars/sn05.yml
@@ -30,3 +30,4 @@ babeld_interface_penalty:
 
 legacy_dom0: true
 radv_announce_default: false
+coordinates: ['50.478069651', '12.334529757']

--- a/host_vars/sn09.yml
+++ b/host_vars/sn09.yml
@@ -33,4 +33,4 @@ apinger_targets2:
 - description: hostway router
   ips:
     - 2a02:790::1
-
+coordinates: ['52.327599348', '9.784306884']

--- a/host_vars/sn10.yml
+++ b/host_vars/sn10.yml
@@ -35,3 +35,4 @@ apinger_targets2:
     - "2a02:790::1"
 exit_ip: "81.3.6.91" 
 fix_netifnames: true
+coordinates: ['52.327422312', '9.783974290']

--- a/roles/ffh.mesh_announce/templates/respondd.conf.j2
+++ b/roles/ffh.mesh_announce/templates/respondd.conf.j2
@@ -40,6 +40,14 @@ FastdPublicKey: {{ fastd_keys[servername].public }}
 # Default WireGuard-public-key to use
 # optional, default is None
 WireGuardPublicKey: {{ wireguard_keys[servername].public }}
+{% if coordinates is defined %}
+# Latitude of the system
+# optional, default: @Latitude
+Latitude: {{ coordinates[0] }}
+# Longitude of the system
+# optional, default: @Longitude
+Longitude: {{ coordinates[1] }}
+{% endif %}
 
 {% for domain in domains_with_dom0 | default( [] ) %}
 [dom{{ domain.id }}]


### PR DESCRIPTION
This adds locations for the supernodes `sn05`, `sn09` and `sn10`.
As `sn01` is an exitnode, its location might, or might not be secret.
Therefore it is not added, yet.

How this looks like can be seen here:
https://hannover.freifunk.net/karte/#/en/map/18/52.32759934806403/9.784306883811952

This is not ideal, yet, as all domains of a supernode are stacked on top of each other.