### PR TITLE
host_vars: better coordinates for sn09 and sn10

### DIFF
--- a/host_vars/sn09.yml
+++ b/host_vars/sn09.yml
@@ -33,4 +33,4 @@ apinger_targets2:
 - description: hostway router
   ips:
     - 2a02:790::1
-coordinates: ['52.327599348', '9.784306884']
+coordinates: ['52.328323878', '9.783394933']

--- a/host_vars/sn10.yml
+++ b/host_vars/sn10.yml
@@ -35,4 +35,4 @@ apinger_targets2:
     - "2a02:790::1"
 exit_ip: "81.3.6.91" 
 fix_netifnames: true
-coordinates: ['52.327422312', '9.783974290']
+coordinates: ['52.328259949', '9.783561230']


### PR DESCRIPTION
Moritz just sent a mail containing more appropriate coordinates:
![img](https://i.imgur.com/5EL9qdM.png)