### PR TITLE
Fix meshinput

### DIFF
--- a/roles/ffh.ferm/templates/ferm.conf.j2
+++ b/roles/ffh.ferm/templates/ferm.conf.j2
@@ -45,13 +45,9 @@ domain (ip ip6) {
 {% endfor %}
 {% endif %}
 {%if batman is defined and domains is defined %}
-{% for intf_prefix in ["mesh_fastd_", "vlan-gt-2", "vx-"] %}
+{% for intf_prefix in ["mesh_fastd_", "bat", "vlan-gt-2", "vx-"] %}
             interface ({% for d in domains %}{{intf_prefix}}{{d.id}} {% endfor %}) jump MESH_INPUT;
 {% endfor %}
-{% endif %}
-
-{%if batman is defined and domains is defined %}
-            interface ({% for d in domains %}bat{{d.id}} {% endfor %}) jump MESH_INPUT;
 {% endif %}
         }
         chain OUTPUT {

--- a/roles/ffh.ferm/templates/ferm.conf.j2
+++ b/roles/ffh.ferm/templates/ferm.conf.j2
@@ -40,7 +40,9 @@ domain (ip ip6) {
             }
 
 {%if batman is defined and legacy_dom0 == true %}
-            interface (mesh_fastd) jump MESH_INPUT;
+{% for intf in ["mesh_fastd", "bat0"] %}
+            interface ({{intf}}) jump MESH_INPUT;
+{% endfor %}
 {% endif %}
 {%if batman is defined and domains is defined %}
 {% for intf_prefix in ["mesh_fastd_", "vlan-gt-2", "vx-"] %}
@@ -48,9 +50,6 @@ domain (ip ip6) {
 {% endfor %}
 {% endif %}
 
-{%if batman is defined and legacy_dom0 == true %}
-            interface (bat0) jump MESH_INPUT;
-{% endif %}
 {%if batman is defined and domains is defined %}
             interface ({% for d in domains %}bat{{d.id}} {% endfor %}) jump MESH_INPUT;
 {% endif %}

--- a/roles/ffh.ferm/templates/ferm.conf.j2
+++ b/roles/ffh.ferm/templates/ferm.conf.j2
@@ -40,7 +40,7 @@ domain (ip ip6) {
             }
 
 {%if batman is defined and legacy_dom0 == true %}
-{% for intf in ["mesh_fastd", "bat0"] %}
+{% for intf in ["mesh_fastd", "bat0", "vlan-gt-20"] %}
             interface ({{intf}}) jump MESH_INPUT;
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
This should add `vlan-gt-20` to mesh_input and therefor fix #207 ;
furthermore the ferm template is now cleaner.