### PR TITLE
autoupdate_wg.py: remove keepalive handshake

### DIFF
--- a/roles/ffh.mesh_wireguard_remotes_peers_git/templates/autoupdate_wg.py.j2
+++ b/roles/ffh.mesh_wireguard_remotes_peers_git/templates/autoupdate_wg.py.j2
@@ -130,7 +130,6 @@ def wg_modify_peer(pubkey, iface, remove=False):
         else:
             allowed=calc_ll(pubkey)
             peer = {'public_key': pubkey,
-                    'persistent_keepalive': 25,
                     'allowed_ips': [allowed]}
             wg.set(iface, peer=peer)
             if verbose:


### PR DESCRIPTION
3.7K keys times 15 domains every 25 seconds
=> 2220 useless handshakes per second, that are destined to fail

The handshakes are not really a problem, but for them we need to call a rather expensive curve-pubkey function.

If we need keepalives, we should have them on the router side.
If we need them from this side, we should dynamically set them for connected peers.

To keep it simple I'd suggest we try it without serverside handshakes first.



To stick with the numbers:
With 3.7K keys on SN09 it hammers itself to a load of 20, where it stays, due to proper scheduling;
Without these handshakes the server sat at a load of 0.44 after a few minutes.