### PR TITLE
Revert "mesh-announce: change to own repo"

### DIFF
--- a/roles/ffh.mesh_announce/tasks/main.yml
+++ b/roles/ffh.mesh_announce/tasks/main.yml
@@ -26,13 +26,11 @@
     dest: /opt/mesh-announce
     owner: auto
 
-# repo=https://github.com/ffnord/mesh-announce.git
-# change back when https://github.com/ffnord/mesh-announce/pull/64 got merged
 - name: Clone mesh_announce
   become: yes
   become_user: auto
   git: >
-    repo=https://github.com/freifunkh/mesh-announce.git
+    repo=https://github.com/ffnord/mesh-announce.git
     dest=/opt/mesh-announce
     accept_hostkey=true
   register: code


### PR DESCRIPTION
> As all of our current PRs have been merged upstream and appear to be working well.
> 
> This reverts commit 0e64161b16545c636d89e79b9dc9b02c83258acc.

We do not have any open PRs against upstream since https://github.com/ffnord/mesh-announce/pull/84 has been merged an hour ago.

(compare https://github.com/ffnord/mesh-announce/pulls)

I'll archive our mesh-announce fork after this got merged.