### PR TITLE
web: redirect alias locations like dirs

### DIFF
--- a/host_vars/web.yml
+++ b/host_vars/web.yml
@@ -43,25 +43,39 @@ nginx_sites:
   tls_redirect_to_https: true
   php: true
   locations:
+    - location: /api
+      rewrite_params: '^ /api/ permanent'
     - location: /api/
       expires: -1
       alias: /var/www/apps/api/
+    - location: /download
+      rewrite_params: '^ /download/ permanent'
     - location: /download/
       directory_index: true
       disable_symlinks: true
       alias: /var/www/apps/download/
+    - location: /gluon-firmware-wizard
+      rewrite_params: '^ /gluon-firmware-wizard/ permanent'
     - location: /gluon-firmware-wizard/
       alias: /var/www/apps/gluon-firmware-selector/
     - location: /karte/config.json
       alias: /var/www/apps/meshviewer_configs/karte.json
     - location: /friedhof/config.json
       alias: /var/www/apps/meshviewer_configs/friedhof.json
+    - location: /karte
+      rewrite_params: '^ /karte/ permanent'
     - location: /karte/
       alias: /var/www/apps/meshviewer/
+    - location: /friedhof
+      rewrite_params: '^ /friedhof/ permanent'
     - location: /friedhof/
       alias: /var/www/apps/meshviewer/
+    - location: /device-pictures
+      rewrite_params: '^ /device-pictures/ permanent'
     - location: /device-pictures/
       alias: /var/www/apps/device-pictures/pictures-svg/
+    - location: /sshauto
+      rewrite_params: '^ /sshauto/ permanent'
     - location: /sshauto/
       alias: /var/www/apps/sshauto/
 


### PR DESCRIPTION
This seems like the quickest way to do this. One could probably look into wheter it's possible to teach [templates/05-nginx-site-location.j2](https://github.com/freifunkh/ansible/blob/master/roles/ffh.nginx/templates/05-nginx-site-location.j2) how to figure this out on it's own or at least create some shortcut. But without the ability to test this i didn't want to try a more advanced way.


#### Additional Context:

Alias Locations should have a trailing slash to avoid path traversal: https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md

---

> If a location is defined by a prefix string that ends with the slash character, and requests are processed by one of [proxy_pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), [fastcgi_pass](https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_pass), [uwsgi_pass](https://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_pass), [scgi_pass](https://nginx.org/en/docs/http/ngx_http_scgi_module.html#scgi_pass), [memcached_pass](https://nginx.org/en/docs/http/ngx_http_memcached_module.html#memcached_pass), or [grpc_pass](https://nginx.org/en/docs/http/ngx_http_grpc_module.html#grpc_pass), then the special processing is performed. In response to a request with URI equal to this string, but without the trailing slash, a permanent redirect with the code 301 will be returned to the requested URI with the slash appended. 

Source: https://nginx.org/en/docs/http/ngx_http_core_module.html#location
