### PR TITLE
radvd,dhcp4: switch to MTU 1280

### DIFF
--- a/roles/ffh.kea-dhcp4-server/templates/kea-dhcp4.conf.j2
+++ b/roles/ffh.kea-dhcp4-server/templates/kea-dhcp4.conf.j2
@@ -62,7 +62,7 @@
 			{
 				"name": "interface-mtu",
 				"data": "1280"
-				// "always-send": true
+				"always-send": true
 			}
 		],
 

--- a/roles/ffh.radv_server/templates/radvd.conf.j2
+++ b/roles/ffh.radv_server/templates/radvd.conf.j2
@@ -8,6 +8,7 @@ interface bat0
  AdvDefaultLifetime 0;
 {% endif %}
  MaxRtrAdvInterval 60;
+ AdvLinkMTU 1280;
  AdvRASolicitedUnicast on;
 
  prefix {{ mesh_prefix }}:{{ sn }}00::/64 {
@@ -37,6 +38,7 @@ interface bat{{ domain.id }}
  AdvDefaultLifetime 0;
 {% endif %}
  MaxRtrAdvInterval 60;
+ AdvLinkMTU 1280;
  AdvRASolicitedUnicast on;
 
  prefix {{ mesh_prefix }}:{{ sn }}{{ domain.id }}::/64 {


### PR DESCRIPTION
As a takeaway from last weekends hackathon there is the suggestion to switch to a lower MTU to prevent fragmentation.

Ideas, suggestions, objections?